### PR TITLE
Added rate limit to webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ pitch_apparent_attenuation{name="Pumpkin Ale", color="purple"} 32.32
 
 ## Webhook
 
-Unlimited webhooks can be configured using the config option `webhook_urls`.  Each Tilt status broadcast will result in a webhook call to all URLs.
+Unlimited webhooks URLs can be configured using the config option `webhook_urls`.  Tilt broadcasts are passed to each URL at a max rate of 1 broadcast per second to avoid
+overwhelming the web servers with large amounts of data.
 
 Webhooks are sent as HTTP POST with the following json payload:
 

--- a/pitch/pitch.py
+++ b/pitch/pitch.py
@@ -81,7 +81,7 @@ def simulate_beacons():
     })
     while True:
         beacon_callback(None, None, fake_packet, dict())
-        time.sleep(1)
+        time.sleep(0.25)
 
 
 def beacon_callback(bt_addr, rssi, packet, additional_info):
@@ -96,11 +96,11 @@ def beacon_callback(bt_addr, rssi, packet, additional_info):
         for provider in enabled_providers:
             try:
                 provider.update(tilt_status)
-            except RateLimitException as e:
+            except RateLimitException:
                 # nothing to worry about, just called this too many times (locally)
                 print("Skipping update due to rate limiting for provider {}".format(provider))
             except Exception as e:
-                #todo: better logging of errors
+                # todo: better logging of errors
                 print(e)
         # Log it to console/stdout
         print(tilt_status.json())

--- a/pitch/providers/file.py
+++ b/pitch/providers/file.py
@@ -5,6 +5,7 @@ from interface import implements
 import logging
 import logging.handlers
 
+
 class FileCloudProvider(implements(CloudProviderBase)):
 
     def __init__(self, config: PitchConfig):

--- a/pitch/providers/webhook.py
+++ b/pitch/providers/webhook.py
@@ -1,6 +1,7 @@
 from ..models import TiltStatus
 from ..abstractions import CloudProviderBase
 from interface import implements
+from ratelimit import limits
 import requests
 
 
@@ -16,6 +17,7 @@ class WebhookCloudProvider(implements(CloudProviderBase)):
     def start(self):
         pass
 
+    @limits(calls=1, period=1)
     def update(self, tilt_status: TiltStatus):
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
         requests.post(self.url, headers=headers, data=tilt_status.json())


### PR DESCRIPTION
Adds basic 1 call per second rate limit to each configured webhook.  This should likely be made configurable in the future but is sufficient as a short term solution to avoid huge amounts of webhook calls.  (Tilts can broadcast multiple times a second leading to lots of HTTP calls)