### PR TITLE
Added basic influxDB batching

### DIFF
--- a/pitch/pitch.py
+++ b/pitch/pitch.py
@@ -18,7 +18,8 @@ uuid_to_colors = {
         "a495bb60-c5b1-4b44-b512-1370f02d74de": "blue",
         "a495bb50-c5b1-4b44-b512-1370f02d74de": "orange",
         "a495bb70-c5b1-4b44-b512-1370f02d74de": "pink",
-        "a495bb40-c5b1-4b44-b512-1370f02d74de": "purple"
+        "a495bb40-c5b1-4b44-b512-1370f02d74de": "purple",
+        "a495bb40-c5b1-4b44-b512-1370f02d74df": "simulated"  # reserved for fake beacons during simulation mode
     }
 
 colors_to_uuid = dict((v, k) for k, v in uuid_to_colors.items())
@@ -75,7 +76,7 @@ def simulate_beacons():
     print("...started: Tilt Beacon Simulator")
     # Using Namespace to trick a dict into a 'class'
     fake_packet = argparse.Namespace(**{
-        'uuid': colors_to_uuid['purple'],
+        'uuid': colors_to_uuid['simulated'],
         'major': 70,
         'minor': 1035
     })


### PR DESCRIPTION
InfluxDB client has a batch argument, but unfortunately, it assumed you already have a list/batch saved rather than handling the queueing/batching for you.

This PR adds a simple list based batch ontop of the influxDB client to ensure proper batching, which should avoid making large amounts of InfluxDB write calls.