### PR TITLE
Feature/color rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Custom configurations can be used by creating a file `pitch.json` in the working
 | ---------------------------- | ---------------------------- | --------------------- |
 | `simulate_beacons` (bool) | Creates fake Tilt beacon events instead of scanning, useful for testing | False |
 | `webhook_urls` (array) | Adds webhook URLs for Tilt status updates | None/empty |
+| `webhook_limit_rate` (int) | Number of webhooks to fire for the limit period (per URL) | 1 |
+| `webhook_limit_period` (int) | Period for rate limiting (in seconds) | 1 |
 | `log_file_path` (str) | Path to file for JSON event logging | `pitch_log.json` |
 | `log_file_max_mb` (int) | Max JSON log file size in megabytes | `10` |
 | `prometheus_enabled` (bool) | Enable/Disable Prometheus metrics | `true` |
@@ -45,11 +47,19 @@ Custom configurations can be used by creating a file `pitch.json` in the working
 | `influxdb_port` (int) | Port for InfluxDB database | None/empty |
 | `influxdb_database` (str) | Name of InfluxDB database | None/empty |
 | `influxdb_username` (str) | Username for InfluxDB | None/empty |
-| `influxdb_batch_size` (int) | Number of events to batch | `10` |
+| `influxdb_batch_size` (int) | Number of events to batch.  Data is not saved to InfluxDB until this threshold is met | `10` |
 | `influxdb_timeout_seconds` (int) | Timeout of InfluxDB reads/writes | `5` |
 | `brewfather_custom_stream_url` (str) | URL of Brewfather Custom Stream | None/empty |
 | `{color}_name` (str) | Name of your brew, where {color} is the color of the Tilt (purple, red, etc) | Color (e.g. purple, red, etc) |
 | `{color}_original_gravity` (float) | Original gravity of the beer, where {color} is the color of the Tilt (purple, red, etc) | None/empty |
+
+## Rate Limiting and Batching
+
+A single Tilt can emit several events per second.  To avoid overloading integrations with data they may support rate limiting or batching.  Batching
+generally builds up a queue, once the max queue size is met the data is sent as a single batch, while rate limiting will drop events if they are 
+being sent too frequently.
+
+Refer to the above configuration and the integration list below for details on how this works for different integrations.
 
 ## Running without a Tilt or on Mac/Windows
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Don't see one you want, send a PR implementing [CloudProviderBase](https://githu
 
 ## Prometheus Metrics
 
-Prometheus metrics are hosted on port 8000.  For each Tilt the followed Prometheus metrics are created:
+Prometheus metrics are hosted on port 8000 by default.  No rate limiting or batching is used for Prometheus.  
+
+For each Tilt the followed Prometheus metrics are created:
 
 ```
 # HELP pitch_beacons_received_total Number of beacons received
@@ -110,8 +112,7 @@ pitch_apparent_attenuation{name="Pumpkin Ale", color="purple"} 32.32
 
 ## Webhook
 
-Unlimited webhooks URLs can be configured using the config option `webhook_urls`.  Tilt broadcasts are passed to each URL at a max rate of 1 broadcast per second to avoid
-overwhelming the web servers with large amounts of data.
+Unlimited webhooks URLs can be configured using the config option `webhook_urls`.  Webhooks are rate limited per URL and per Tilt, the rate limit is configurable.
 
 Webhooks are sent as HTTP POST with the following json payload:
 
@@ -143,7 +144,8 @@ Tilt status broadcast events can be logged to a json file using the config optio
 ## InfluxDB Metrics
 
 Metrics can be sent to an InfluxDB database.  See [Configuration section](#Configuration) for setting this up.  Pitch does not create the database
-so it must be created before using Pitch.  
+so it must be created before using Pitch.  Tilt events are sent to InfluxDB in batches, data is not sent until the batch size is reached.  The batch size
+does not take color into account, so a batch of 50 purple events works the same as 25 purple and 25 red.
 
 Each beacon event from a Tilt will create a measurement like this:
 
@@ -173,7 +175,7 @@ SELECT mean("gravity") AS "mean_gravity" FROM "pitch"."autogen"."tilt" WHERE tim
 ## Brewfather
 
 Tilt data can be logged to Brewfather using their Custom Log Stream feature.  See [Configuration section](#Configuration) for setting this up in the Pitch config.  Brewfather
-only allows logging data every fifteen minutes (per Tilt).  Devices will show as `PitchTilt{color}`.
+only allows logging data every fifteen minutes per Tilt which Pitch adheres to.  Devices will show as `PitchTilt{color}`.
 
 To setup login into Brewfather > Settings > PowerUps > Enable Custom Stream > Copy the URL into your Pitch config
 

--- a/pitch/__init__.py
+++ b/pitch/__init__.py
@@ -1,1 +1,2 @@
 from .pitch import pitch_main
+from .rate_limiter import RateLimiter

--- a/pitch/configuration/pitch_config.py
+++ b/pitch/configuration/pitch_config.py
@@ -7,6 +7,8 @@ class PitchConfig:
     def __init__(self, data: dict):
         # Webhook
         self.webhook_urls = list()
+        self.webhook_limit_rate = 1
+        self.webhook_limit_period = 1
         # File Path
         self.log_file_path = 'pitch_log.json'
         self.log_file_max_mb = 10

--- a/pitch/pitch.py
+++ b/pitch/pitch.py
@@ -3,10 +3,10 @@ import threading
 import time
 from pyfiglet import Figlet
 from beacontools import BeaconScanner
-from ratelimit import RateLimitException
 from .models import TiltStatus
 from .providers import *
 from .configuration import PitchConfig
+from .rate_limiter import RateLimitedException
 
 #############################################
 # Statics
@@ -97,7 +97,8 @@ def beacon_callback(bt_addr, rssi, packet, additional_info):
         for provider in enabled_providers:
             try:
                 provider.update(tilt_status)
-            except RateLimitException:
+                print("Updated provider {}".format(provider))
+            except RateLimitedException:
                 # nothing to worry about, just called this too many times (locally)
                 print("Skipping update due to rate limiting for provider {}".format(provider))
             except Exception as e:
@@ -117,7 +118,8 @@ def add_webhook_providers(config: PitchConfig):
     # Multiple webhooks can be fired, so create them dynamically and add to
     # all providers static list
     for url in config.webhook_urls:
-        all_providers.append(WebhookCloudProvider(url))
+        all_providers.append(WebhookCloudProvider(url, config))
+
 
 def start_message():
     f = Figlet(font='slant')

--- a/pitch/pitch.py
+++ b/pitch/pitch.py
@@ -97,10 +97,10 @@ def beacon_callback(bt_addr, rssi, packet, additional_info):
         for provider in enabled_providers:
             try:
                 provider.update(tilt_status)
-                print("Updated provider {}".format(provider))
+                print("Updated provider {} for color {}".format(provider, color))
             except RateLimitedException:
                 # nothing to worry about, just called this too many times (locally)
-                print("Skipping update due to rate limiting for provider {}".format(provider))
+                print("Skipping update due to rate limiting for provider {} for color {}".format(provider, color))
             except Exception as e:
                 # todo: better logging of errors
                 print(e)

--- a/pitch/providers/brewfather_custom_stream.py
+++ b/pitch/providers/brewfather_custom_stream.py
@@ -18,7 +18,7 @@
 from ..models import TiltStatus
 from ..abstractions import CloudProviderBase
 from ..configuration import PitchConfig
-from ..rate_limiter import RateLimiter
+from ..rate_limiter import DeviceRateLimiter
 from interface import implements
 import requests
 import json
@@ -30,7 +30,7 @@ class BrewfatherCustomStreamCloudProvider(implements(CloudProviderBase)):
         self.url = config.brewfather_custom_stream_url
         self.temp_unit = BrewfatherCustomStreamCloudProvider._get_temp_unit(config)
         self.str_name = "Brewfather ({})".format(self.url)
-        self.rate_limiter = RateLimiter(rate=1, period=(60 * 15))  # 15 minutes
+        self.rate_limiter = DeviceRateLimiter(rate=1, period=(60 * 15))  # 15 minutes
 
     def __str__(self):
         return self.str_name
@@ -39,7 +39,7 @@ class BrewfatherCustomStreamCloudProvider(implements(CloudProviderBase)):
         pass
 
     def update(self, tilt_status: TiltStatus):
-        self.rate_limiter.approve()
+        self.rate_limiter.approve(tilt_status.color)
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
         payload = self._get_payload(tilt_status)
         result = requests.post(self.url, headers=headers, data=json.dumps(payload))

--- a/pitch/providers/influxdb.py
+++ b/pitch/providers/influxdb.py
@@ -4,6 +4,7 @@ from ..configuration import PitchConfig
 from interface import implements
 from influxdb import InfluxDBClient
 
+
 class InfluxDbCloudProvider(implements(CloudProviderBase)):
 
     def __init__(self, config: PitchConfig):

--- a/pitch/providers/webhook.py
+++ b/pitch/providers/webhook.py
@@ -1,4 +1,4 @@
-from ..rate_limiter import RateLimiter
+from ..rate_limiter import DeviceRateLimiter
 from ..models import TiltStatus
 from ..abstractions import CloudProviderBase
 from interface import implements
@@ -11,7 +11,7 @@ class WebhookCloudProvider(implements(CloudProviderBase)):
     def __init__(self, url, config: PitchConfig):
         self.url = url
         self.str_name = "Webhook ({})".format(url)
-        self.rate_limiter = RateLimiter(rate=config.webhook_limit_rate, period=config.webhook_limit_period)
+        self.rate_limiter = DeviceRateLimiter(rate=config.webhook_limit_rate, period=config.webhook_limit_period)
 
     def __str__(self):
         return self.str_name
@@ -20,7 +20,7 @@ class WebhookCloudProvider(implements(CloudProviderBase)):
         pass
 
     def update(self, tilt_status: TiltStatus):
-        self.rate_limiter.approve()
+        self.rate_limiter.approve(tilt_status.color)
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
         requests.post(self.url, headers=headers, data=tilt_status.json())
 

--- a/pitch/providers/webhook.py
+++ b/pitch/providers/webhook.py
@@ -1,15 +1,17 @@
+from ..rate_limiter import RateLimiter
 from ..models import TiltStatus
 from ..abstractions import CloudProviderBase
 from interface import implements
-from ratelimit import limits
+from ..configuration import PitchConfig
 import requests
 
 
 class WebhookCloudProvider(implements(CloudProviderBase)):
 
-    def __init__(self, url):
+    def __init__(self, url, config: PitchConfig):
         self.url = url
         self.str_name = "Webhook ({})".format(url)
+        self.rate_limiter = RateLimiter(rate=config.webhook_limit_rate, period=config.webhook_limit_period)
 
     def __str__(self):
         return self.str_name
@@ -17,8 +19,8 @@ class WebhookCloudProvider(implements(CloudProviderBase)):
     def start(self):
         pass
 
-    @limits(calls=1, period=1)
     def update(self, tilt_status: TiltStatus):
+        self.rate_limiter.approve()
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
         requests.post(self.url, headers=headers, data=tilt_status.json())
 

--- a/pitch/rate_limiter.py
+++ b/pitch/rate_limiter.py
@@ -1,0 +1,25 @@
+import time
+
+
+class RateLimitedException(Exception):
+    pass
+
+
+class RateLimiter:
+    def __init__(self, rate=1, period=1):
+        self.rate = rate
+        self.period = period
+        self.allowance = rate
+        self.last_check = time.time()
+
+    def approve(self):
+        current = time.time()
+        time_passed = current - self.last_check
+        self.last_check = current
+        self.allowance = self.allowance + time_passed * (self.rate / self.period)
+        if self.allowance > self.rate:
+            self.allowance = self.rate
+        if self.allowance < 1:
+            raise RateLimitedException()
+        else:
+            self.allowance = self.allowance - 1

--- a/pitch/rate_limiter.py
+++ b/pitch/rate_limiter.py
@@ -5,6 +5,24 @@ class RateLimitedException(Exception):
     pass
 
 
+class DeviceRateLimiter:
+    def __init__(self, rate=1, period=1):
+        self.default_rate = rate
+        self.default_period = period
+        self.device_limiters = dict()
+
+    def approve(self, device_id):
+        if device_id not in self.device_limiters:
+            # No limiter for this device yet
+            self.device_limiters[device_id] = self._get_new_limiter()
+        # Check if this color is too frequent
+        limiter = self.device_limiters[device_id]
+        limiter.approve()
+
+    def _get_new_limiter(self):
+        return RateLimiter(self.default_rate, self.default_period)
+
+
 class RateLimiter:
     def __init__(self, rate=1, period=1):
         self.rate = rate
@@ -23,3 +41,4 @@ class RateLimiter:
             raise RateLimitedException()
         else:
             self.allowance = self.allowance - 1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ jsonpickle
 python-interface
 pyfiglet
 influxdb
-ratelimit


### PR DESCRIPTION
Replaces the decorator based rate limiting library with an internal implementation.  Rate limiting is now configurable, and it is possible to rate limit an entire provider/integration or per-color.

* BrewFather - now rate limited once per fiften minutes, per color
* Webhook - now rate limited once per second, per color and is now configurable