### PR TITLE
Added temp and gravity ranges for tilt scans

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -21,6 +21,9 @@ jobs:
         sudo apt-get install libbluetooth-dev -y
         python -m pip install --upgrade pip setuptools wheel twine
         pip install -r requirements.txt
+    - name: Run Tests
+      run: |
+        python -m unittest discover test 
     - name: Build and publish
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       env:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Custom configurations can be used by creating a file `pitch.json` in the working
 | ---------------------------- | ---------------------------- | --------------------- | --------------------- |
 | `queue_size` (int) | Max queue size for all Tilt event broadcasts.  Events are removed from the queue once all enabled providers have handled the event.  New events are dropped when the queue is maxed.  | `3` | No example yet (PRs welcome!) |
 | `queue_empty_sleep_seconds` (int) | Time in seconds Pitch will sleep when the queue reaches 0. The higher the value the less CPU time Pitch uses.  Can be 0 or negative (this disables sleep and Pitch will always run). | `1` | No example yet (PRs welcome!) |
+| `temp_range_min` (int) | Minimum temperature (Fahrenheit) for Pitch to consider a Tilt broadcast to be valid. | `32` | No example yet (PRs welcome!) |
+| `temp_range_max` (int) | Maximum temperature (Fahrenheit) for Pitch to consider a Tilt broadcast to be valid. | `212` | No example yet (PRs welcome!) |
+| `gravity_range_min` (int) | Minimum gravity for Pitch to consider a Tilt broadcast to be valid. | `0.7` | No example yet (PRs welcome!) |
+| `gravity_range_max` (int) | Maximum gravity for Pitch to consider a Tilt broadcast to be valid. | `1.4` | No example yet (PRs welcome!) |
 | `webhook_urls` (array) | Adds webhook URLs for Tilt status updates | None/empty | No example yet (PRs welcome!) |
 | `webhook_limit_rate` (int) | Number of webhooks to fire for the limit period (per URL) | 1 | No example yet (PRs welcome!) |
 | `webhook_limit_period` (int) | Period for rate limiting (in seconds) | 1 | No example yet (PRs welcome!) |

--- a/pitch/configuration/pitch_config.py
+++ b/pitch/configuration/pitch_config.py
@@ -8,6 +8,11 @@ class PitchConfig:
         # Queue
         self.queue_size = 3
         self.queue_empty_sleep_seconds = 1
+        # Broadcast Data ranges
+        self.temp_range_min = 32
+        self.temp_range_max = 212
+        self.gravity_range_min = 0.7
+        self.gravity_range_max = 1.4
         # Webhook
         self.webhook_urls = list()
         self.webhook_limit_rate = 1

--- a/pitch/models/tilt_status.py
+++ b/pitch/models/tilt_status.py
@@ -15,6 +15,8 @@ class TiltStatus(JsonSerialize):
         self.gravity = current_gravity + config.get_gravity_offset(color)
         self.alcohol_by_volume = TiltStatus.get_alcohol_by_volume(self.original_gravity, self.gravity)
         self.apparent_attenuation = TiltStatus.get_apparent_attenuation(self.original_gravity, self.gravity)
+        self.temp_valid = (config.temp_range_min < self.temp_fahrenheit and self.temp_fahrenheit < config.temp_range_max)
+        self.gravity_valid = (config.gravity_range_min < self.gravity and self.gravity < config.gravity_range_max)
 
     @staticmethod
     def get_celsius(temp_fahrenheit):

--- a/pitch/pitch.py
+++ b/pitch/pitch.py
@@ -129,7 +129,12 @@ def _beacon_callback(bt_addr, rssi, packet, additional_info):
         # major = degrees in F (int)
         # minor = gravity (int) - needs to be converted to float (e.g. 1035 -> 1.035)
         tilt_status = TiltStatus(color, packet.major, _get_decimal_gravity(packet.minor), config)
-        pitch_q.put_nowait(tilt_status)
+        if not tilt_status.temp_valid:
+            print("Ignoring broadcast due to invalid temperature: {}F".format(tilt_status.temp_fahrenheit))
+        elif not tilt_status.gravity_valid:
+            print("Ignoring broadcast due to invalid gravity: " + tilt_status.gravity)
+        else:
+            pitch_q.put_nowait(tilt_status)
 
 
 def _handle_pitch_queue(enabled_providers: list, console_log: bool):

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+from .tilt_status_tests import TiltStatusTests

--- a/test/test_tilt_status.py
+++ b/test/test_tilt_status.py
@@ -1,0 +1,28 @@
+import unittest
+from pitch.configuration import PitchConfig
+from pitch.models import TiltStatus
+
+class TiltStatusTests(unittest.TestCase):
+
+    def setUp(self):
+        self.config = PitchConfig({})
+
+    def test_temp_low(self):
+        tilt_status = TiltStatus("purple", self.config.temp_range_min - 1, 1.050, self.config)
+        self.assertFalse(tilt_status.temp_valid, msg="Temp is greater than min")
+
+    def test_temp_high(self):
+        tilt_status = TiltStatus("purple", self.config.temp_range_max + 1, 1.050, self.config)
+        self.assertFalse(tilt_status.temp_valid, msg="Temp is less than max")
+        
+    def test_gravity_low(self):
+        tilt_status = TiltStatus("purple", 70, self.config.gravity_range_min - 0.001, self.config)
+        self.assertFalse(tilt_status.gravity_valid, msg="Gravity is greater than min")
+
+    def test_gravity_high(self):
+        tilt_status = TiltStatus("purple", 70, self.config.gravity_range_max + 0.001, self.config)
+        self.assertFalse(tilt_status.gravity_valid, msg="Gravity is less than max")
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds ranges with min/max values for gravity and temperature.  If a Tilt broadcast is outside these ranges it is ignored and this is logged to console.

Closes #25 