### PR TITLE
Add support for InfluxDB 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following features are implemented, planned, or will be investigated in the 
 * [x] Calibrate Tilt readings with known good values
 * [x] Prometheus Metrics
 * [x] Tilt status log file (JSON)
-* [X] InfluxDB Metrics
+* [X] InfluxDB 1.0 and 2.0 Metrics 
 * [X] Multiple logging and metric sources simultaneously
 * [X] Webhooks for supporting generic integrations (similar to Tilt's Cloud Logging feature)
 * [X] Gravity, original gravity, ABV, temperature and apparent attenuation
@@ -55,6 +55,10 @@ Custom configurations can be used by creating a file `pitch.json` in the working
 | `influxdb_username` (str) | Username for InfluxDB | None/empty | No example yet (PRs welcome!) |
 | `influxdb_password` (str) | Password for InfluxDB | None/empty | No example yet (PRs welcome!) |
 | `influxdb_batch_size` (int) | Number of events to batch.  Data is not saved to InfluxDB until this threshold is met | `10` | No example yet (PRs welcome!) |
+| `influxdb2_url` (str) | URL of InfluxDB 2.0 database | None/empty | `http://localhost:8086` |
+| `influxdb2_token` (str) | Token for writing to InfluxDB 2.0 | None/empty | a base64 encoded string |
+| `influxdb2_org` (str) | Org for InfluxDB 2.0 database | None/empty | `org_name` |
+| `influxdb2_bucket` (str) | Bucket to write data to in InfluxDB 2.0 | None/empty | `bucket_name`
 | `influxdb_timeout_seconds` (int) | Timeout of InfluxDB reads/writes | `5` | No example yet (PRs welcome!) |
 | `brewfather_custom_stream_url` (str) | URL of Brewfather Custom Stream | None/empty | No example yet (PRs welcome!) |
 | `grainfather_custom_stream_urls` (dict) | Dict of color (key) and URLs (value) | None/empty | [Example config](examples/grainfather/pitch.json) |
@@ -205,6 +209,15 @@ and can be queried with something like:
 ```sql
 SELECT mean("gravity") AS "mean_gravity" FROM "pitch"."autogen"."tilt" WHERE time > :dashboardTime: AND time < :upperDashboardTime: AND "name"='Pumpkin Ale' GROUP BY time(:interval:) FILL(previous)
 ```
+
+## InfluxDB 2.0 Metrics
+
+Metrics can be sent to an InfluxDB 2.0 database. See [Configuration section](#Configuration) for details on setting it up.  Pitch does not create the bucket.
+This integration uses the same batching logic, output format, and configuration as the 1.0 integration above.
+
+Shared configuration values:
+- `influxdb_timeout`
+- `influxdb_batch_size`
 
 ## Brewfather
 

--- a/pitch/configuration/pitch_config.py
+++ b/pitch/configuration/pitch_config.py
@@ -31,6 +31,11 @@ class PitchConfig:
         self.influxdb_password = None
         self.influxdb_batch_size = 10
         self.influxdb_timeout_seconds = 5
+        # InfluxDB2
+        self.influxdb2_url = None
+        self.influxdb2_org = None
+        self.influxdb2_token = None
+        self.influxdb2_bucket = None
         # Brewfather
         self.brewfather_custom_stream_url = None
         self.brewfather_custom_stream_temp_unit = "F"

--- a/pitch/pitch.py
+++ b/pitch/pitch.py
@@ -35,6 +35,7 @@ normal_providers = [
         PrometheusCloudProvider(config),
         FileCloudProvider(config),
         InfluxDbCloudProvider(config),
+        InfluxDb2CloudProvider(config),
         BrewfatherCustomStreamCloudProvider(config),
         BrewersFriendCustomStreamCloudProvider(config),
         GrainfatherCustomStreamCloudProvider(config)

--- a/pitch/providers/__init__.py
+++ b/pitch/providers/__init__.py
@@ -2,6 +2,7 @@ from .prometheus import PrometheusCloudProvider
 from .webhook import WebhookCloudProvider
 from .file import FileCloudProvider
 from .influxdb import InfluxDbCloudProvider
+from .influxdb2 import InfluxDb2CloudProvider
 from .brewfather_custom_stream import BrewfatherCustomStreamCloudProvider
 from .brewersfriend_custom_stream import BrewersFriendCustomStreamCloudProvider
 from .calibration import CalibrationCloudProvider

--- a/pitch/providers/influxdb2.py
+++ b/pitch/providers/influxdb2.py
@@ -1,0 +1,55 @@
+from ..models import TiltStatus
+from ..abstractions import CloudProviderBase
+from ..configuration import PitchConfig
+from interface import implements
+from influxdb_client import InfluxDBClient
+from influxdb_client.client.write_api import SYNCHRONOUS, WritePrecision
+
+
+class InfluxDb2CloudProvider(implements(CloudProviderBase)):
+
+    def __init__(self, config: PitchConfig):
+        self.config = config
+        self.str_name = "InfluxDb2 ({})".format(config.influxdb2_url)
+        self.batch = list()
+
+    def __str__(self):
+        return self.str_name
+
+    def start(self):
+        self.client = InfluxDBClient(
+            url=self.config.influxdb2_url,
+            token=self.config.influxdb2_token,
+            org=self.config.influxdb2_org,
+            timeout=self.config.influxdb_timeout_seconds)
+        self.write_api = self.client.write_api(write_options=SYNCHRONOUS)
+
+    def update(self, tilt_status: TiltStatus):
+        self.batch.append(self.get_point(tilt_status))
+        if len(self.batch) < self.config.influxdb_batch_size:
+            return
+        # Batch size has been met, update and clear
+        self.write_api.write(
+            bucket=self.config.influxdb2_bucket,
+            record=self.batch,
+            write_precision=WritePrecision.MS)
+        self.batch.clear()
+
+    def enabled(self):
+        return (self.config.influxdb2_url)
+
+    def get_point(self, tilt_status: TiltStatus):
+        return {
+            "measurement": "tilt",
+            "tags": {
+                "color": tilt_status.color,
+                "name": tilt_status.name
+            },
+            "fields": {
+                "temp_fahrenheit": tilt_status.temp_fahrenheit,
+                "temp_celsius": tilt_status.temp_celsius,
+                "gravity": tilt_status.gravity,
+                "alcohol_by_volume": tilt_status.alcohol_by_volume,
+                "apparent_attenuation": tilt_status.apparent_attenuation
+            }
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ jsonpickle
 python-interface
 pyfiglet
 influxdb
+influxdb-client[ciso]
 beacontools[scan]
 pybluez


### PR DESCRIPTION
Adds support to exporting data to InfluxDB 2.0.

I started out with just supporting 2.0 but am not the biggest fan of how it ended up duplicating a bunch of logic between this and the 1.0 support. What would be your thoughts on creating a common base for them to reduce the duplication?