### PR TITLE
Tilt Pro support, Plato value and bugfixes

### DIFF
--- a/pitch/models/tilt_status.py
+++ b/pitch/models/tilt_status.py
@@ -17,7 +17,7 @@ class TiltStatus(JsonSerialize):
             temp_fahrenheit /= 10
 
         self.temp_fahrenheit = temp_fahrenheit + config.get_temp_offset(color)
-        self.temp_celsius = TiltStatus.get_celsius(temp_fahrenheit)
+        self.temp_celsius = TiltStatus.get_celsius(self.temp_fahrenheit)
         self.original_gravity = config.get_original_gravity(color)
         self.gravity = current_gravity + config.get_gravity_offset(color)
         self.alcohol_by_volume = TiltStatus.get_alcohol_by_volume(self.original_gravity, self.gravity)

--- a/pitch/models/tilt_status.py
+++ b/pitch/models/tilt_status.py
@@ -20,6 +20,7 @@ class TiltStatus(JsonSerialize):
         self.temp_celsius = TiltStatus.get_celsius(self.temp_fahrenheit)
         self.original_gravity = config.get_original_gravity(color)
         self.gravity = current_gravity + config.get_gravity_offset(color)
+        self.degrees_plato = TiltStatus.get_degrees_plato(self.gravity)
         self.alcohol_by_volume = TiltStatus.get_alcohol_by_volume(self.original_gravity, self.gravity)
         self.apparent_attenuation = TiltStatus.get_apparent_attenuation(self.original_gravity, self.gravity)
         self.temp_valid = (config.temp_range_min < self.temp_fahrenheit and self.temp_fahrenheit < config.temp_range_max)
@@ -28,6 +29,10 @@ class TiltStatus(JsonSerialize):
     @staticmethod
     def get_celsius(temp_fahrenheit):
         return round((temp_fahrenheit - 32) * 5.0/9.0, 1)
+
+    @staticmethod
+    def get_degrees_plato(gravity):
+        return round(1111.14 * gravity - 630.272 * gravity ** 2 + 135.997 * gravity ** 3 - 616.868, 1)
 
     @staticmethod
     def get_alcohol_by_volume(original_gravity, current_gravity):

--- a/pitch/models/tilt_status.py
+++ b/pitch/models/tilt_status.py
@@ -9,6 +9,13 @@ class TiltStatus(JsonSerialize):
         self.timestamp = datetime.datetime.now()
         self.color = color
         self.name = config.get_brew_name(color)
+        self.hd = current_gravity > 2  # Tilt Pro?
+
+        # With Tilt Pro values have more precision, which has to be adjusted
+        if self.hd:
+            current_gravity /= 10
+            temp_fahrenheit /= 10
+
         self.temp_fahrenheit = temp_fahrenheit + config.get_temp_offset(color)
         self.temp_celsius = TiltStatus.get_celsius(temp_fahrenheit)
         self.original_gravity = config.get_original_gravity(color)
@@ -20,7 +27,7 @@ class TiltStatus(JsonSerialize):
 
     @staticmethod
     def get_celsius(temp_fahrenheit):
-        return round((temp_fahrenheit - 32) * 5.0/9.0)
+        return round((temp_fahrenheit - 32) * 5.0/9.0, 1)
 
     @staticmethod
     def get_alcohol_by_volume(original_gravity, current_gravity):

--- a/pitch/providers/influxdb2.py
+++ b/pitch/providers/influxdb2.py
@@ -21,7 +21,7 @@ class InfluxDb2CloudProvider(implements(CloudProviderBase)):
             url=self.config.influxdb2_url,
             token=self.config.influxdb2_token,
             org=self.config.influxdb2_org,
-            timeout=self.config.influxdb_timeout_seconds)
+            timeout=self.config.influxdb_timeout_seconds*1000)
         self.write_api = self.client.write_api(write_options=SYNCHRONOUS)
 
     def update(self, tilt_status: TiltStatus):

--- a/pitch/providers/influxdb2.py
+++ b/pitch/providers/influxdb2.py
@@ -49,6 +49,7 @@ class InfluxDb2CloudProvider(implements(CloudProviderBase)):
                 "temp_fahrenheit": tilt_status.temp_fahrenheit,
                 "temp_celsius": tilt_status.temp_celsius,
                 "gravity": tilt_status.gravity,
+                "degrees_plato": tilt_status.degrees_plato,
                 "alcohol_by_volume": tilt_status.alcohol_by_volume,
                 "apparent_attenuation": tilt_status.apparent_attenuation
             }


### PR DESCRIPTION
Hi, first off, I want to say thank you for creating this library 👍. I was looking for a solution to streamline data from my new Tilt Pro Mini device to InfluxDB/Grafana and this _seemed_ to be the perfect solution for me.

Though, I had to make some adjustments to get it working, that I'd like to address with this PR.

Changes made:
- Support for Tilt Pro devices (raw numbers from those devices are 10x larger, because of a added precision -> have to be divided by 10 to get proper gravity/temperature values)
- Added a calculated value in degrees plato
- ... which is also pushed to InfluxDB
- Bugfix: Calculation of celsius based on the offset-adjusted fahrenheit value, and rounded it to the first decimal for better precision
- Bugfix: Timeout to InfluxDB has to be in milliseconds, but value is provided as seconds, so you've been ending up with a super-small timeout value

Let me know what you think!

Cheers!